### PR TITLE
remove fwhole-program option to show public function on shared library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,8 @@ ifeq ($(COMP),gcc)
 	PGO_USE = -fprofile-correction -fprofile-use
 	
 	ifeq ($(BUILD),optimize)
-		CFLAGS += -Ofast -fwhole-program -flto -DNDEBUG
+		# modify for libedax by sensuikan1973.20121/1/21
+		CFLAGS += -Ofast -flto -DNDEBUG
 	else
 		CFLAGS += -O0 -g -DDEBUG
 	endif
@@ -93,7 +94,8 @@ ifeq ($(COMP),gcc-old)
 	CFLAGS = -std=c99 -pedantic -W -Wall -Wextra -pipe -D_GNU_SOURCE=1
 	
 	ifeq ($(BUILD),optimize)
-		CFLAGS += -O3 -fwhole-program -DNDEBUG
+		# modify for libedax by sensuikan1973.20121/1/21
+		CFLAGS += -O3 -DNDEBUG
 	else
 		CFLAGS += -O0 -g -DDEBUG
 	endif
@@ -143,7 +145,8 @@ ifeq ($(COMP),g++)
 	PGO_USE = -fprofile-correction -fprofile-use
 
 	ifeq ($(BUILD),optimize)
-		CFLAGS += -Ofast -fwhole-program -flto -DNDEBUG
+		# modify for libedax by sensuikan1973.20121/1/21
+		CFLAGS += -Ofast -flto -DNDEBUG
 	else
 		CFLAGS += -O0 -g -DDEBUG
 	endif


### PR DESCRIPTION
I built libedax for Linux(ubuntu18).
It successed, but I can't access libedax functions (e.g. libedax_initialize).
Actually, I confirmed the output(libedax.so) doesn't have any functions of libedax.

I found the cause is `fwhole-program` option. (See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)
That deals with the public functions as static, I can't find symbols which I want.
Because We don't' need this option for  shared library, I removed `fwhole-program`.

For your ref, these are samples (from CI of my repo https://github.com/sensuikan1973/libedax4dart/pull/1) ↓
* fail sample (liedax revision: https://github.com/lavox/edax-reversi/tree/40da48f6e676bc47815e14cfda71e80a1705fcc9) → https://github.com/sensuikan1973/libedax4dart/runs/1734874667?check_suite_focus=true
* success sample (libedax revision: https://github.com/sensuikan1973/edax-reversi/tree/50ff6d9bffdf9661707a98decbd7152f254a848a) → https://github.com/sensuikan1973/libedax4dart/runs/1736830835?check_suite_focus=true